### PR TITLE
[ENTESB-15424]Quickstarts don't expose routes on OCP 4.x

### DIFF
--- a/src/main/fabric8/route.yml
+++ b/src/main/fabric8/route.yml
@@ -1,3 +1,6 @@
+
+apiVersion: "route.openshift.io/v1"
+kind: Route
 spec:
   to:
     kind: Service


### PR DESCRIPTION
(cherry picked from commit 8dd95f3491c9e4104466b0a75ff43f25673c0bc4)